### PR TITLE
Added: Improve button custom field design consistency and sub-field description support

### DIFF
--- a/assets/src/scss/base/_general.scss
+++ b/assets/src/scss/base/_general.scss
@@ -190,6 +190,11 @@
 				color: var(--directorist-color-primary);
 			}
 		}
+		.directorist-form-button-field{
+			display: flex;
+			flex-direction: column;
+			gap: 40px 0;
+		}
 		.directorist-checkbox {
 			.directorist-checkbox__label {
 				margin-left: 0;

--- a/assets/src/scss/component/_button.scss
+++ b/assets/src/scss/component/_button.scss
@@ -200,21 +200,21 @@
 
   &.directorist-btn-outline-primary {
     background: transparent;
-    border: 1px solid var(--directorist-color-primary) !important;
-    color: var(--directorist-color-primary);
+    border: 1px solid var(--directorist-color-btn-primary-border) !important;
+    color: var(--directorist-color-btn-primary-bg);
     &:focus,&:hover{
       color:var(--directorist-color-white);
-      background-color: var(--directorist-color-primary);
+      background-color: var(--directorist-color-btn-primary-bg);
     }
   }
 
   &.directorist-btn-outline-secondary {
     background: transparent;
-    border: 1px solid var(--directorist-color-secondary) !important;
-    color: var(--directorist-color-secondary);
+    border: 1px solid var(--directorist-color-btn-secondary-border) !important;
+    color: var(--directorist-color-btn-secondary-bg);
     &:focus,&:hover{
       color:var(--directorist-color-white);
-      background-color: var(--directorist-color-secondary);
+      background-color: var(--directorist-color-btn-secondary-bg);
     }
   }
 
@@ -284,6 +284,7 @@
   }
 
   &.directorist-btn-xs {
+    padding: 0 15px;
     min-height: 36px;
   }
 

--- a/assets/src/scss/component/listing-details/_contact-info.scss
+++ b/assets/src/scss/component/listing-details/_contact-info.scss
@@ -87,7 +87,7 @@
       flex: 100%;
       margin-top: 0;
     }
-    a {
+    a:not(.directorist-btn) {
       color: var(--directorist-color-body);
     }
   }

--- a/assets/src/scss/component/listing-details/_details-content.scss
+++ b/assets/src/scss/component/listing-details/_details-content.scss
@@ -113,12 +113,14 @@
 
 	.directorist-details-info-wrap {
 		a {
-			font-size: 15px;
-			text-decoration: none;
-			box-shadow: none;
-			color: var(--directorist-color-body);
-			&:hover {
-				color: var(--directorist-color-primary);
+			&:not(.directorist-btn) {
+				font-size: 15px;
+				text-decoration: none;
+				box-shadow: none;
+				color: var(--directorist-color-body);
+				&:hover {
+					color: var(--directorist-color-primary);
+				}
 			}
 		}
 		ul {
@@ -174,6 +176,14 @@
 					height: auto;
 					line-height: unset;
 					color: var(--directorist-color-body);
+				}
+			}
+		}
+		.directorist-single-info-button{
+			.directorist-single-info__value{
+				.directorist-icon-mask:after{
+					width: 12px;
+					height: 12px;
 				}
 			}
 		}

--- a/includes/modules/multi-directory-setup/builder-custom-fields.php
+++ b/includes/modules/multi-directory-setup/builder-custom-fields.php
@@ -810,18 +810,6 @@ return apply_filters(
                         'value' => 'custom-button',
                     ]
                 ),
-                'label' => [
-                    'type'        => 'text',
-                    'label'       => __( 'Label', 'directorist' ),
-                    'value'       => __( 'Button', 'directorist' ),
-                    'description' => __( 'Field name shown in the Add Listing form (e.g., Booking Link, Website Link).', 'directorist' ),
-                ],
-                'description' => [
-                    'type'        => 'text',
-                    'label'       => __( 'Description', 'directorist' ),
-                    'value'       => '',
-                    'description' => __( 'Optional help text displayed below the input field.', 'directorist' ),
-                ],
                 'button_text' => [
                     'type'        => 'text',
                     'label'       => __( 'Button Text Label', 'directorist' ),
@@ -834,6 +822,12 @@ return apply_filters(
                     'value'       => __( 'Visit Now', 'directorist' ),
                     'description' => __( 'Placeholder example for the Button Text input (e.g., Book Now, Visit Site).', 'directorist' ),
                 ],
+                'button_text_description' => [
+                    'type'        => 'text',
+                    'label'       => __( 'Button Text Description', 'directorist' ),
+                    'value'       => '',
+                    'description' => __( 'Help text displayed below the Button Text input (e.g., This text will appear as the button label on your listing).', 'directorist' ),
+                ],
                 'button_url_label' => [
                     'type'        => 'text',
                     'label'       => __( 'Button URL Label', 'directorist' ),
@@ -845,6 +839,12 @@ return apply_filters(
                     'label'       => __( 'Button URL Placeholder', 'directorist' ),
                     'value'       => 'https://yourlink.com',
                     'description' => __( 'Placeholder example for the Button URL input (e.g., https://yourlink.com).', 'directorist' ),
+                ],
+                'button_url_description' => [
+                    'type'        => 'text',
+                    'label'       => __( 'Button URL Description', 'directorist' ),
+                    'value'       => '',
+                    'description' => __( 'Help text displayed below the Button URL input (e.g., Add the full website link).', 'directorist' ),
                 ],
                 'button_style' => [
                     'type'    => 'select',

--- a/templates/listing-form/custom-fields/button.php
+++ b/templates/listing-form/custom-fields/button.php
@@ -10,8 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 <div class="directorist-form-group directorist-form-button-field">
 
-    <?php $listing_form->field_label_template( $data ); ?>
-
     <?php
     $button_value = is_array( $data['value'] ) ? $data['value'] : [];
     $button_text = isset( $button_value['button_text'] ) ? $button_value['button_text'] : '';
@@ -20,22 +18,32 @@ if ( ! defined( 'ABSPATH' ) ) exit;
     $button_url_placeholder = isset( $data['button_url_placeholder'] ) ? $data['button_url_placeholder'] : '';
     ?>
 
-    <div class="directorist-form-button-field__inputs">
         <div class="directorist-form-button-field__text">
-            <label for="<?php echo esc_attr( $data['field_key'] . '_text' ); ?>">
-                <?php echo esc_html( ! empty( $data['button_text'] ) ? $data['button_text'] : __( 'Button Text', 'directorist' ) ); ?>
-            </label>
-            <input type="text" autocomplete="off" name="<?php echo esc_attr( $data['field_key'] . '[button_text]' ); ?>" id="<?php echo esc_attr( $data['field_key'] . '_text' ); ?>" class="directorist-form-element" value="<?php echo esc_attr( $button_text ); ?>" placeholder="<?php echo esc_attr( $button_text_placeholder ); ?>" <?php $listing_form->required( $data ); ?>>
+
+        <label class="directorist-form-label" for="<?php echo esc_attr( $data['field_key'] . '_text' ); ?>">
+            <?php echo esc_html( ! empty( $data['button_text'] ) ? $data['button_text'] : __( 'Button Text', 'directorist' ) ); ?>:<?php echo ! empty( $data['required'] ) ? '<span class="directorist-form-required"> *</span>' : ''; ?>
+        </label>
+
+        <input type="text" autocomplete="off" name="<?php echo esc_attr( $data['field_key'] . '[button_text]' ); ?>" id="<?php echo esc_attr( $data['field_key'] . '_text' ); ?>" class="directorist-form-element" value="<?php echo esc_attr( $button_text ); ?>" placeholder="<?php echo esc_attr( $button_text_placeholder ); ?>" <?php $listing_form->required( $data ); ?>>
+
+        <?php if ( ! empty( $data['button_text_description'] ) ) : ?>
+            <div class="directorist-form-description"><?php echo esc_html( $data['button_text_description'] ); ?></div>
+        <?php endif; ?>
+
         </div>
 
         <div class="directorist-form-button-field__link">
-            <label for="<?php echo esc_attr( $data['field_key'] . '_link' ); ?>">
-                <?php echo esc_html( ! empty( $data['button_url_label'] ) ? $data['button_url_label'] : __( 'Website URL', 'directorist' ) ); ?>
-            </label>
-            <input type="url" autocomplete="off" name="<?php echo esc_attr( $data['field_key'] . '[button_url_label]' ); ?>" id="<?php echo esc_attr( $data['field_key'] . '_link' ); ?>" class="directorist-form-element" value="<?php echo esc_attr( $button_url_label ); ?>" placeholder="<?php echo esc_attr( $button_url_placeholder ); ?>" <?php $listing_form->required( $data ); ?>>
-        </div>
-    </div>
 
-    <?php $listing_form->field_description_template( $data ); ?>
+        <label class="directorist-form-label" for="<?php echo esc_attr( $data['field_key'] . '_link' ); ?>">
+            <?php echo esc_html( ! empty( $data['button_url_label'] ) ? $data['button_url_label'] : __( 'Website URL', 'directorist' ) ); ?>:<?php echo ! empty( $data['required'] ) ? '<span class="directorist-form-required"> *</span>' : ''; ?>
+        </label>
+
+        <input type="url" autocomplete="off" name="<?php echo esc_attr( $data['field_key'] . '[button_url_label]' ); ?>" id="<?php echo esc_attr( $data['field_key'] . '_link' ); ?>" class="directorist-form-element" value="<?php echo esc_attr( $button_url_label ); ?>" placeholder="<?php echo esc_attr( $button_url_placeholder ); ?>" <?php $listing_form->required( $data ); ?>>
+
+        <?php if ( ! empty( $data['button_url_description'] ) ) : ?>
+            <div class="directorist-form-description"><?php echo esc_html( $data['button_url_description'] ); ?></div>
+        <?php endif; ?>
+
+        </div>
 
 </div>

--- a/templates/single/custom-fields/button.php
+++ b/templates/single/custom-fields/button.php
@@ -26,9 +26,12 @@ $target       = ! empty( $form_data['open_in_new_tab'] ) ? ' target="_blank" rel
 
     <?php if ( $button_text && $button_url_label ) : ?>
         <div class="directorist-single-info__value">
-            <a class="directorist-btn directorist-btn-<?php echo esc_attr( $button_style ); ?>"
+            <a class="directorist-btn directorist-btn-xs directorist-btn-outline-<?php echo esc_attr( $button_style ); ?>"
                href="<?php echo esc_url( $button_url_label ); ?>"<?php echo $target; ?>>
                 <?php echo esc_html( $button_text ); ?>
+                <span class="directorist-icon-arrow-right">
+                    <?php directorist_icon( 'fas fa-external-link-alt' ); ?>
+                </span>
             </a>
         </div>
     <?php endif; ?>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Mark completed items with an [x] -->
- [ ] Bugfix
- [ ] Security fix
- [x] Improvement
- [x] New Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Text changes
- [ ] Other... Please describe:

## Description
This PR improves the Button custom field to align with the design pattern used by other listing form fields, introduces sub-field level description support, and updates related styles for consistency and better UX.

### PHP Changes
- Listing form sub-field labels now use the `directorist-form-label` class with `:` suffix and required `*` indicator — consistent with Text, URL, Email, and other field templates.
- Added `button_text_description` and `button_url_description` builder options so admins can define help text for each sub-field.
- Removed unused top-level label and description builder options (Button field uses sub-field labels instead).
- Removed dead `field_label_template()` and `field_description_template()` calls from the listing form template.
- Updated single listing button to use outline style with an external link icon for improved UX.

### SCSS Changes
- Updated button component styles for outline variant and sizing (`_button.scss`).
- Refined listing details content and contact info styles (`_details-content.scss`, `_contact-info.scss`).
- Added general base styles to support Button field layout (`_general.scss`).

### How to Test
1. Go to **Directorist → Listing Form Builder** and add or edit a Button custom field.
2. Set descriptions for Button Text and Button URL.
3. Create or edit a listing and verify labels, required indicators, and help text display correctly.
4. View the listing frontend and confirm outline button style, icon, and functionality.
5. Check overall layout and styles to ensure no regressions.

## Any linked issues
Fixes #

## Checklist
- [x] My code follows the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
